### PR TITLE
Add strictness flag which causes LSODA to exit on warning

### DIFF
--- a/numbalsoda/driver.py
+++ b/numbalsoda/driver.py
@@ -20,29 +20,32 @@ else:
     name = "liblsoda.dylib"
 liblsoda = ct.CDLL(rootdir+name)
 lsoda_wrapper = liblsoda.lsoda_wrapper
-lsoda_wrapper.argtypes = [ct.c_void_p, ct.c_int, ct.c_void_p, ct.c_void_p,\
-                          ct.c_int, ct.c_void_p, ct.c_void_p, ct.c_double,\
-                          ct.c_double, ct.c_int, ct.c_void_p]
+lsoda_wrapper.argtypes = [ct.c_void_p, ct.c_int, ct.c_void_p, ct.c_void_p,
+                          ct.c_int, ct.c_void_p, ct.c_void_p, ct.c_double,
+                          ct.c_double, ct.c_int, ct.c_void_p, ct.c_int]
 lsoda_wrapper.restype = None
 
 @njit
-def lsoda(funcptr, u0, t_eval, data = np.array([0.0], np.float64), rtol = 1.0e-3, atol = 1.0e-6, mxstep = 10000):
+def lsoda(funcptr, u0, t_eval, data = np.array([0.0], np.float64), rtol=1.0e-3,
+          atol=1.0e-6, mxstep=10000,
+          exit_on_warning=False):
+
     neq = len(u0)
     nt = len(t_eval)
     usol = np.empty((nt,neq),dtype=np.float64)
     success = np.array(999,np.int32)
     lsoda_wrapper(funcptr, neq, u0.ctypes.data, data.ctypes.data, nt,
                   t_eval.ctypes.data, usol.ctypes.data, rtol, atol,
-                  mxstep, success.ctypes.data)
+                  mxstep, success.ctypes.data, exit_on_warning)
     success_ = True
     if success != 1:
         success_ = False
     return usol, success_
-    
+
 @nb.extending.intrinsic
 def address_as_void_pointer(typingctx, src):
     """ returns a void pointer from a given memory address """
-    from numba import types 
+    from numba import types
     from numba.core import cgutils
     sig = types.voidptr(src)
     def codegen(cgctx, builder, sig, args):

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -287,7 +287,7 @@ c-----------------------------------------------------------------------
 void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
                   double *t, double tout, int itask, int *istate, int iopt,
                   int jt, array<int, 7> &iworks, array<double, 4> &rworks,
-                  void *_data)
+                  void *_data, bool exit_on_warning)
 {
     assert(tout > *t);
 
@@ -828,6 +828,13 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
                     stderr,
                     "         such that in the machine, t + h_ = t on the next step\n");
                 fprintf(stderr, "         solver will continue anyway.\n");
+
+		if (exit_on_warning){
+			*istate =-2;
+      terminate2(y, t);
+			return;
+		}
+
                 if (nhnil == mxhnil)
                 {
                     cerr << "lsoda -- above warning has been issued " << nhnil
@@ -2240,7 +2247,7 @@ void LSODA::_freevectors(void)
 void LSODA::lsoda_update(LSODA_ODE_SYSTEM_TYPE f, const size_t neq,
                          vector<double> &y, vector<double> &yout, double *t,
                          const double tout, int *istate, void * _data,
-                         double rtol, double atol 
+                         double rtol, double atol, bool exit_on_warning
                         )
 {
     array<int, 7> iworks = {{0}};
@@ -2266,5 +2273,5 @@ void LSODA::lsoda_update(LSODA_ODE_SYSTEM_TYPE f, const size_t neq,
     for (size_t i = 1; i <= neq; i++)
         yout[i] = y[i - 1];
 
-    lsoda(f, neq, yout, t, tout, itask, istate, iopt, jt, iworks, rworks, _data);
+    lsoda(f, neq, yout, t, tout, itask, istate, iopt, jt, iworks, rworks, _data, exit_on_warning);
 }

--- a/src/LSODA.cpp
+++ b/src/LSODA.cpp
@@ -830,7 +830,7 @@ void LSODA::lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
                 fprintf(stderr, "         solver will continue anyway.\n");
 
 		if (exit_on_warning){
-			*istate =-2;
+			*istate = -2;
       terminate2(y, t);
 			return;
 		}

--- a/src/LSODA.h
+++ b/src/LSODA.h
@@ -61,7 +61,7 @@ public:
 
     void lsoda(LSODA_ODE_SYSTEM_TYPE f, const size_t neq, vector<double> &y,
                double *t, double tout, int itask, int *istate, int iopt, int jt,
-               array<int, 7> &iworks, array<double, 4> &rworks, void *_data);
+               array<int, 7> &iworks, array<double, 4> &rworks, void *_data, bool exit_on_warning);
 
     void correction(const size_t neq, vector<double> &y, LSODA_ODE_SYSTEM_TYPE f,
                     size_t *corflag, double pnorm, double *del, double *delp,
@@ -75,7 +75,8 @@ public:
     void lsoda_update(LSODA_ODE_SYSTEM_TYPE f, const size_t neq,
                       vector<double> &y, std::vector<double> &yout, double *t,
                       const double tout, int *istate, void *const _data,
-                      double rtol = 1e-6, double atol = 1e-6 // Tolerance
+                      double rtol = 1e-6, double atol = 1e-6, // Tolerance
+                      bool exit_on_warning = false
                      );
 
     void terminate(int *istate);

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -6,11 +6,12 @@
 
 extern "C"
 {
-    
+
 void lsoda_wrapper(void (*rhs)(double t, double *u, double *du, void *data),
                    int neq, double* u0, void* data, int nt, double* teval,
-                   double* usol, double rtol, double atol, int mxstep, int* success){
-  
+                   double* usol, double rtol, double atol, int mxstep,
+                   int* success, bool exit_on_warning=false){
+
   LSODA lsoda;
   lsoda.mxstep = mxstep;
   std::vector<double> y;
@@ -19,7 +20,7 @@ void lsoda_wrapper(void (*rhs)(double t, double *u, double *du, void *data),
   y.resize(neq);
   yout.resize(neq);
   *success = 1;
-  
+
   // load in initial conditions
   for (int i = 0; i < neq; i++){
     y[i] = u0[i];
@@ -27,27 +28,27 @@ void lsoda_wrapper(void (*rhs)(double t, double *u, double *du, void *data),
   }
   double t = teval[0];
   double tout;
-  
+
   for (int i = 1; i < nt; i++){
     if (teval[i] < teval[i-1]){
       *success = 0;
       return;
     }
-    
+
     tout = teval[i];
     lsoda.lsoda_update(rhs, neq, y, yout, &t, tout, &istate, data, rtol, atol);
-    
+
     if (istate <= 0){
       // there is a problem!
       *success = 0;
       return;
     }
-    
+
     // update y for next step
     for (int j = 0; j < neq; j++){
       y[j] = yout[j+1];
     }
-    
+
     // save solution
     for (int j = 0; j < neq; j++){
       usol[j + neq*i] = yout[j+1];

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -36,7 +36,7 @@ void lsoda_wrapper(void (*rhs)(double t, double *u, double *du, void *data),
     }
 
     tout = teval[i];
-    lsoda.lsoda_update(rhs, neq, y, yout, &t, tout, &istate, data, rtol, atol);
+    lsoda.lsoda_update(rhs, neq, y, yout, &t, tout, &istate, data, rtol, atol, exit_on_warning);
 
     if (istate <= 0){
       // there is a problem!

--- a/tests/test_exit_on_warning.py
+++ b/tests/test_exit_on_warning.py
@@ -1,0 +1,54 @@
+import numpy as np
+import numba as nb
+import unittest
+
+import numbalsoda
+
+
+class TestNumbaLSODA(unittest.TestCase):
+
+    def setUp(self):
+        # numbalsoda
+        @nb.cfunc(numbalsoda.lsoda_sig, boundscheck=False)
+        def f_nb(t, u_, du_, p_):
+            du_[0] = p_[0]*u_[0] * np.sin(t)
+
+        self.f_nb = f_nb
+        self.funcptr = self.f_nb.address
+
+        self.atol = 1e-9
+        self.rtol = 1e-9
+
+    def test_exit_on_warning(self):
+        """Test that setting exit_on_warning=True causes the solver to return
+         prematurely terminate for an ill-conditioned ODE.
+
+        """
+
+        t_eval = np.linspace(100, 101, 11)
+        u0 = np.array([1])
+        args = np.array([1e15])
+
+        usol_nb, success = numbalsoda.lsoda(self.funcptr, u0, t_eval, args,
+                                            exit_on_warning=True,
+                                            atol=self.atol, rtol=self.rtol)
+        self.assertFalse(success)
+
+    def test_solve_ode(self):
+        """Test that the problem can be solved successfully if warnings
+        are ignored.
+
+        """
+
+        t_eval = np.linspace(100, 101, 11)
+        u0 = np.array([1])
+        args = np.array([1e15])
+
+        usol_nb, success = numbalsoda.lsoda(self.funcptr, u0, t_eval, args,
+                                            atol=self.atol, rtol=self.rtol)
+        self.assertTrue(success)
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add flags to the Python wrapper which tell LSODA to terminate whenever the
` 'lsoda -- warning..internal t = %g and h_ = %g are such that in the machine, t + h_ = t on the next step"
warning is issued.

Currently, the user is only told about this warning through stderr. Allowing the user to set numbalsoda to be more strict will allow for better unit testing in code using numbalsoda.

To do this, a flag is added to the numba function `lsoda()`, which defaults to the original behaviour. The same flag is added to `LSODA::lsoda`, `LSODA::update` and `lsoda_wrapper`. When this flag is set to true and the above warning is issued, the solver will terminate with istate* = -2.